### PR TITLE
New func to specify minimum capacity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 
 go:
-  - "1.8"
   - "1.9"
   - "1.10"
   - "1.11"
+  - "1.12"
   - "tip"
 
 before_script:

--- a/deque.go
+++ b/deque.go
@@ -13,17 +13,6 @@ type Deque struct {
 	minCap int
 }
 
-// New creates a new Deque that has a minimum capacity of 2^minCapacityExp.  If
-// the value of the minimum capacity is less than or equal to the minimum
-// allowed, then New returns the same as new(Deque).
-func New(minCapacityExp uint) *Deque {
-	q := new(Deque)
-	if 1<<minCapacityExp > minCapacity {
-		q.minCap = 1 << minCapacityExp
-	}
-	return q
-}
-
 // Len returns the number of elements currently stored in the queue.
 func (q *Deque) Len() int {
 	return q.count
@@ -187,6 +176,21 @@ func (q *Deque) Rotate(n int) {
 		// Calculate new head and tail using bitwise modulus.
 		q.head = (q.head + 1) & modBits
 		q.tail = (q.tail + 1) & modBits
+	}
+}
+
+// SetMinCapacity sets a minimum capacity of 2^minCapacityExp.  If the value of
+// the minimum capacity is less than or equal to the minimum allowed, then
+// capacity is set to the minimum allowed.  This may be called at anytime to
+// set a new minimum capacity.
+//
+// Setting a larger minimum capacity may be used to prevent resizing when the
+// number of stored items changes frequently across a wide range.
+func (q *Deque) SetMinCapacity(minCapacityExp uint) {
+	if 1<<minCapacityExp > minCapacity {
+		q.minCap = 1 << minCapacityExp
+	} else {
+		q.minCap = minCapacity
 	}
 }
 

--- a/deque.go
+++ b/deque.go
@@ -6,10 +6,22 @@ const minCapacity = 16
 
 // Deque represents a single instance of the deque data structure.
 type Deque struct {
-	buf   []interface{}
-	head  int
-	tail  int
-	count int
+	buf    []interface{}
+	head   int
+	tail   int
+	count  int
+	minCap int
+}
+
+// New creates a new Deque that has a minimum capacity of 2^minCapacityExp.  If
+// the value of the minimum capacity is less than or equal to the minimum
+// allowed, then New returns the same as new(Deque).
+func New(minCapacityExp uint) *Deque {
+	q := new(Deque)
+	if 1<<minCapacityExp > minCapacity {
+		q.minCap = 1 << minCapacityExp
+	}
+	return q
 }
 
 // Len returns the number of elements currently stored in the queue.
@@ -191,7 +203,10 @@ func (q *Deque) next(i int) int {
 // growIfFull resizes up if the buffer is full.
 func (q *Deque) growIfFull() {
 	if len(q.buf) == 0 {
-		q.buf = make([]interface{}, minCapacity)
+		if q.minCap == 0 {
+			q.minCap = minCapacity
+		}
+		q.buf = make([]interface{}, q.minCap)
 		return
 	}
 	if q.count == len(q.buf) {
@@ -201,7 +216,7 @@ func (q *Deque) growIfFull() {
 
 // shrinkIfExcess resize down if the buffer 1/4 full.
 func (q *Deque) shrinkIfExcess() {
-	if len(q.buf) > minCapacity && (q.count<<2) == len(q.buf) {
+	if len(q.buf) > q.minCap && (q.count<<2) == len(q.buf) {
 		q.resize()
 	}
 }

--- a/deque_test.go
+++ b/deque_test.go
@@ -480,9 +480,10 @@ func TestRemoveOutOfRangePanics(t *testing.T) {
 	})
 }
 
-func TestNew(t *testing.T) {
+func TestSetMinCapacity(t *testing.T) {
+	var q Deque
 	exp := uint(8)
-	q := New(8)
+	q.SetMinCapacity(exp)
 	q.PushBack("A")
 	if q.minCap != 1<<exp {
 		t.Fatal("wrong minimum capacity")
@@ -496,6 +497,10 @@ func TestNew(t *testing.T) {
 	}
 	if len(q.buf) != 1<<exp {
 		t.Fatal("wrong buffer size")
+	}
+	q.SetMinCapacity(0)
+	if q.minCap != minCapacity {
+		t.Fatal("wrong minimum capacity")
 	}
 }
 
@@ -590,7 +595,8 @@ func BenchmarkYoyo(b *testing.B) {
 }
 
 func BenchmarkYoyoFixed(b *testing.B) {
-	q := New(16)
+	var q Deque
+	q.SetMinCapacity(16)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 65536; j++ {
 			q.PushBack(j)

--- a/deque_test.go
+++ b/deque_test.go
@@ -480,6 +480,25 @@ func TestRemoveOutOfRangePanics(t *testing.T) {
 	})
 }
 
+func TestNew(t *testing.T) {
+	exp := uint(8)
+	q := New(8)
+	q.PushBack("A")
+	if q.minCap != 1<<exp {
+		t.Fatal("wrong minimum capacity")
+	}
+	if len(q.buf) != 1<<exp {
+		t.Fatal("wrong buffer size")
+	}
+	q.PopBack()
+	if q.minCap != 1<<exp {
+		t.Fatal("wrong minimum capacity")
+	}
+	if len(q.buf) != 1<<exp {
+		t.Fatal("wrong buffer size")
+	}
+}
+
 func assertPanics(t *testing.T, name string, f func()) {
 	defer func() {
 		if r := recover(); r == nil {
@@ -555,6 +574,30 @@ func BenchmarkRemove(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		remove(q, q.Len()/2)
+	}
+}
+
+func BenchmarkYoyo(b *testing.B) {
+	var q Deque
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 65536; j++ {
+			q.PushBack(j)
+		}
+		for j := 0; j < 65536; j++ {
+			q.PopFront()
+		}
+	}
+}
+
+func BenchmarkYoyoFixed(b *testing.B) {
+	q := New(16)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 65536; j++ {
+			q.PushBack(j)
+		}
+		for j := 0; j < 65536; j++ {
+			q.PopFront()
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/gammazero/deque


### PR DESCRIPTION
A larger minimum capacity can be specified to avoid buffer resizing in cases
where the size frequently grows and shrinks across a wide range.

Add module support