### PR TITLE
Add Set and Copy methods

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -117,6 +117,29 @@ func (q *Deque) At(i int) interface{} {
 	return q.buf[(q.head+i)&(len(q.buf)-1)]
 }
 
+// Set puts the element at index i in the queue. Set shares the same purpose
+// than At() but perform the opposite operation. The index i is the same
+// index defined by At(). If the index is invalid, the call panics.
+func (q *Deque) Set(i int, elem interface{}) {
+	if i < 0 || i >= q.count {
+		panic("deque: Set() called with index out of range")
+	}
+	// bitwise modulus
+	q.buf[(q.head+i)&(len(q.buf)-1)] = elem
+}
+
+// Copy takes the indices of two elements and copies the element at index i
+// into index j. Copy is a shortcut for q.Set(j) = q.At(i). The indices i and j
+// are the same indices defined by At(). If one of the indices is invalid, the
+// call panics.
+func (q *Deque) Copy(i int, j int) {
+	if i < 0 || i >= q.count || j < 0 || j >= q.count {
+		panic("deque: Copy() called with index out of range")
+	}
+	// bitwise modulus
+	q.buf[(q.head+j)&(len(q.buf)-1)] = q.buf[(q.head+i)&(len(q.buf)-1)]
+}
+
 // Clear removes all elements from the queue, but retains the current capacity.
 // This is useful when repeatedly reusing the queue at high frequency to avoid
 // GC during reuse.  The queue will not be resized smaller as long as items are

--- a/deque_test.go
+++ b/deque_test.go
@@ -282,6 +282,44 @@ func TestAt(t *testing.T) {
 	}
 }
 
+func TestSet(t *testing.T) {
+	var q Deque
+
+	for i := 0; i < 1000; i++ {
+		q.PushBack(i)
+		q.Set(i, i+50)
+	}
+
+	// Front to back.
+	for j := 0; j < q.Len(); j++ {
+		if q.At(j).(int) != j+50 {
+			t.Errorf("index %d doesn't contain %d", j, j+50)
+		}
+	}
+}
+
+func TestCopy(t *testing.T) {
+	var q Deque
+
+	for i := 0; i < 1000; i++ {
+		q.PushBack(i)
+	}
+
+	// Copy first half in last half
+	for i := 0; i < 500; i++ {
+		q.Copy(i, i+500)
+	}
+
+	for j := 0; j < 500; j++ {
+		if q.At(j).(int) != j {
+			t.Errorf("index %d doesn't contain %d", j, j)
+		}
+		if q.At(j+500).(int) != j {
+			t.Errorf("index %d doesn't contain %d", j+500, j)
+		}
+	}
+}
+
 func TestClear(t *testing.T) {
 	var q Deque
 

--- a/deque_test.go
+++ b/deque_test.go
@@ -482,6 +482,46 @@ func TestAtOutOfRangePanics(t *testing.T) {
 	})
 }
 
+func TestSetOutOfRangePanics(t *testing.T) {
+	var q Deque
+
+	q.PushBack(1)
+	q.PushBack(2)
+	q.PushBack(3)
+
+	assertPanics(t, "should panic when negative index", func() {
+		q.Set(-4, 1)
+	})
+
+	assertPanics(t, "should panic when index greater than length", func() {
+		q.Set(4, 1)
+	})
+}
+
+func TestCopyOutOfRangePanics(t *testing.T) {
+	var q Deque
+
+	q.PushBack(1)
+	q.PushBack(2)
+	q.PushBack(3)
+
+	assertPanics(t, "should panic when negative index", func() {
+		q.Copy(-4, 1)
+	})
+
+	assertPanics(t, "should panic when index greater than length", func() {
+		q.Copy(4, 1)
+	})
+
+	assertPanics(t, "should panic when negative index", func() {
+		q.Copy(1, -4)
+	})
+
+	assertPanics(t, "should panic when index greater than length", func() {
+		q.Copy(1, 4)
+	})
+}
+
 func TestInsertOutOfRangePanics(t *testing.T) {
 	q := new(Deque)
 


### PR DESCRIPTION
This is adding the Set() and Copy() methods with the same intent as At(): to be able to use deque as a more general purpose circular buffer (similar to deque in C++).
Please comment and/or merge.