### PR TITLE
Add Set method

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -117,6 +117,17 @@ func (q *Deque) At(i int) interface{} {
 	return q.buf[(q.head+i)&(len(q.buf)-1)]
 }
 
+// Set puts the element at index i in the queue. Set shares the same purpose
+// than At() but perform the opposite operation. The index i is the same
+// index defined by At(). If the index is invalid, the call panics.
+func (q *Deque) Set(i int, elem interface{}) {
+	if i < 0 || i >= q.count {
+		panic("deque: Set() called with index out of range")
+	}
+	// bitwise modulus
+	q.buf[(q.head+i)&(len(q.buf)-1)] = elem
+}
+
 // Clear removes all elements from the queue, but retains the current capacity.
 // This is useful when repeatedly reusing the queue at high frequency to avoid
 // GC during reuse.  The queue will not be resized smaller as long as items are

--- a/deque_test.go
+++ b/deque_test.go
@@ -282,6 +282,22 @@ func TestAt(t *testing.T) {
 	}
 }
 
+func TestSet(t *testing.T) {
+	var q Deque
+
+	for i := 0; i < 1000; i++ {
+		q.PushBack(i)
+		q.Set(i, i+50)
+	}
+
+	// Front to back.
+	for j := 0; j < q.Len(); j++ {
+		if q.At(j).(int) != j+50 {
+			t.Errorf("index %d doesn't contain %d", j, j+50)
+		}
+	}
+}
+
 func TestClear(t *testing.T) {
 	var q Deque
 
@@ -441,6 +457,22 @@ func TestAtOutOfRangePanics(t *testing.T) {
 
 	assertPanics(t, "should panic when index greater than length", func() {
 		q.At(4)
+	})
+}
+
+func TestSetOutOfRangePanics(t *testing.T) {
+	var q Deque
+
+	q.PushBack(1)
+	q.PushBack(2)
+	q.PushBack(3)
+
+	assertPanics(t, "should panic when negative index", func() {
+		q.Set(-4, 1)
+	})
+
+	assertPanics(t, "should panic when index greater than length", func() {
+		q.Set(4, 1)
 	})
 }
 


### PR DESCRIPTION
This is adding the Set() method with the same intent as At(): to be able to use deque as a more general purpose circular buffer (similar to deque in C++).
Please comment and/or merge.

The request removed the Copy method from #8 .
