### PR TITLE
Allow Len and Cap to work with nil Deque

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -56,11 +56,17 @@ func New(size ...int) *Deque {
 
 // Cap returns the current capacity of the Deque.
 func (q *Deque) Cap() int {
+	if q == nil {
+		return 0
+	}
 	return len(q.buf)
 }
 
 // Len returns the number of elements currently stored in the queue.
 func (q *Deque) Len() int {
+	if q == nil {
+		return 0
+	}
 	return q.count
 }
 
@@ -194,7 +200,7 @@ func (q *Deque) Clear() {
 // back-to-front.  Having Deque provide Rotate() avoids resizing that could
 // happen if implementing rotation using only Pop and Push methods.
 func (q *Deque) Rotate(n int) {
-	if q.count <= 1 {
+	if q.Len() <= 1 {
 		return
 	}
 	// Rotating a multiple of q.count is same as no rotation.

--- a/deque_test.go
+++ b/deque_test.go
@@ -9,6 +9,16 @@ func TestEmpty(t *testing.T) {
 	}
 }
 
+func TestNil(t *testing.T) {
+	var q *Deque
+	if q.Len() != 0 {
+		t.Error("expected q.Len() == 0")
+	}
+	if q.Cap() != 0 {
+		t.Error("expected q.Cap() == 0")
+	}
+}
+
 func TestFrontBack(t *testing.T) {
 	var q Deque
 	q.PushBack("foo")
@@ -108,6 +118,13 @@ func TestSimple(t *testing.T) {
 	for i := 0; i < minCapacity; i++ {
 		q.PushBack(i)
 	}
+	if q.Front() != 0 {
+		t.Fatalf("expected 0 at front, got %d", q.Front().(int))
+	}
+	if q.Back() != minCapacity-1 {
+		t.Fatalf("expected %d at back, got %d", minCapacity-1, q.Back().(int))
+	}
+
 	for i := 0; i < minCapacity; i++ {
 		if q.Front() != i {
 			t.Error("peek", i, "had value", q.Front())


### PR DESCRIPTION
This is similar to calling these on a nil slice or map.  This allows a `nil` `Deque` to work like an empty `Deque` for operations that work with an empty `Deque`.