### PR TITLE
Add iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Deque uses generics to create a Deque that contains items of the type specified.
     var intDeque deque.Deque[int]
 ```
 
+Deque supports iterators that allow traversal or removal of items. When removing items this is useful to avoid intermediate resizes of the internal buffer. It also allows Deque to be used with the stdlib [`slices.Collect`](https://pkg.go.dev/slices#Collect), [`slices.Sorted`](https://pkg.go.dev/slices#Sorted), and others that take [`iter.Seq`](https://pkg.go.dev/iter#Seq) argumments.
+
 ## Example
 
 ```go

--- a/deque.go
+++ b/deque.go
@@ -97,8 +97,8 @@ func (q *Deque[T]) PopFront() T {
 	return ret
 }
 
-// IterPopFront returns an iterator the iteratively removes items from the
-// Front of the deque. This is more efficient than removing items one at a time
+// IterPopFront returns an iterator that iteratively removes items from the
+// front of the deque. This is more efficient than removing items one at a time
 // because it avoids intermediate resizing. If a resize is necessary, only one
 // is done when iteration ends.
 func (q *Deque[T]) IterPopFront() iter.Seq[T] {
@@ -141,7 +141,7 @@ func (q *Deque[T]) PopBack() T {
 	return ret
 }
 
-// IterPopBack returns an iterator the iteratively removes items from the back
+// IterPopBack returns an iterator that iteratively removes items from the back
 // of the deque. This is more efficient than removing items one at a time
 // because it avoids intermediate resizing. If a resize is necessary, only one
 // is done when iteration ends.
@@ -210,20 +210,18 @@ func (q *Deque[T]) Set(i int, item T) {
 }
 
 // Iter returns a go iterator to range over all items in the Deque, yielding
-// the index of each item and the item, from front to back. Modification of
+// each item from front (index 0) to back (index Len()-1). Modification of
 // Deque during iteration panics.
-func (q *Deque[T]) Iter() iter.Seq2[int, T] {
-	return func(yield func(int, T) bool) {
-		if q.Len() == 0 {
-			return
-		}
-		count := q.count
-		head := q.head
-		for i := 0; i < count; i++ {
-			if q.count != count {
+func (q *Deque[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		origHead := q.head
+		origTail := q.tail
+		head := origHead
+		for range q.Len() {
+			if q.head != origHead || q.tail != origTail {
 				panic("deque: modified during iteration")
 			}
-			if !yield(i, q.buf[head]) {
+			if !yield(q.buf[head]) {
 				return
 			}
 			head = q.next(head)
@@ -231,22 +229,20 @@ func (q *Deque[T]) Iter() iter.Seq2[int, T] {
 	}
 }
 
-// RIter returns a go iterator to range over all items in the Deque, yielding
-// the index of each item and the item, from back to front. Modification of
-// Deque during iteration panics.
-func (q *Deque[T]) RIter() iter.Seq2[int, T] {
-	return func(yield func(int, T) bool) {
-		if q.Len() == 0 {
-			return
-		}
-		count := q.count
-		tail := q.tail
-		for i := count - 1; i >= 0; i-- {
-			if q.count != count {
+// RIter returns a reversee go iterator to range over all items in the Deque,
+// yielding each item from back (index Len()-1) to front (index 0).
+// Modification of Deque during iteration panics.
+func (q *Deque[T]) RIter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		origHead := q.head
+		origTail := q.tail
+		tail := origTail
+		for range q.Len() {
+			if q.head != origHead || q.tail != origTail {
 				panic("deque: modified during iteration")
 			}
 			tail = q.prev(tail)
-			if !yield(i, q.buf[tail]) {
+			if !yield(q.buf[tail]) {
 				return
 			}
 		}

--- a/deque.go
+++ b/deque.go
@@ -229,7 +229,7 @@ func (q *Deque[T]) Iter() iter.Seq[T] {
 	}
 }
 
-// RIter returns a reversee go iterator to range over all items in the Deque,
+// RIter returns a reverse go iterator to range over all items in the Deque,
 // yielding each item from back (index Len()-1) to front (index 0).
 // Modification of Deque during iteration panics.
 func (q *Deque[T]) RIter() iter.Seq[T] {

--- a/deque_test.go
+++ b/deque_test.go
@@ -688,24 +688,22 @@ func TestIter(t *testing.T) {
 	}
 
 	// Front to back.
-	expect := 0
-	for i, item := range q.Iter() {
-		if i != expect {
-			t.Fatalf("expected index %d, got %d", expect, i)
-		}
+	var i int
+	for item := range q.Iter() {
 		if item != i {
 			t.Errorf("index %d contains %d", i, item)
 		}
 		if i == 40 {
 			break
 		}
-		expect++
+		i++
 	}
 
 	assertPanics(t, "Iter must panic when deque modified during iteration", func() {
-		for i, _ := range q.Iter() {
-			if i == 42 {
+		for item := range q.Iter() {
+			if item == 42 {
 				q.PushBack(51)
+				q.PopFront()
 			}
 		}
 	})
@@ -723,25 +721,23 @@ func TestRIter(t *testing.T) {
 		q.PushBack(i)
 	}
 
-	// Back to fron
-	expect := 49
-	for i, item := range q.RIter() {
-		if i != expect {
-			t.Fatalf("expected index %d, got %d", expect, i)
-		}
+	// Back to front
+	i := q.Len() - 1
+	for item := range q.RIter() {
 		if item != i {
 			t.Fatalf("index %d contains %d", i, item)
 		}
 		if i == 10 {
 			break
 		}
-		expect--
+		i--
 	}
 
 	assertPanics(t, "RIter must panic when deque modified during iteration", func() {
-		for i, _ := range q.RIter() {
-			if i == 42 {
+		for item := range q.RIter() {
+			if item == 42 {
 				q.PushBack(51)
+				q.PopFront()
 			}
 		}
 	})

--- a/deque_test.go
+++ b/deque_test.go
@@ -707,6 +707,14 @@ func TestIter(t *testing.T) {
 			}
 		}
 	})
+
+	for i := 50; i < 60; i++ {
+		q.PushFront(i)
+	}
+	items := slices.Sorted(q.Iter())
+	if !slices.IsSorted(items) {
+		t.Fatal("expected sorted slice")
+	}
 }
 
 func TestRIter(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gammazero/deque
 
-go 1.22
+go 1.23


### PR DESCRIPTION
- `Iter` returns front-to-back go iterator
- `RIter` returns back-to-front go iterator
- `IterPopFront` returns go iterator that removes items from front of Deque
- `IterPopBack` returns go iterator that removes items from back fo Deque

Using iterators to operate on sequences of items in `Deque` can avoid unnecessary range checks and multiple resizes. Iterators also allow `Deque` to be used with `slices.Collect`, `slices.Sorted`, etc.