### PR TITLE
Make .Clear faster by ~20%

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -166,12 +166,19 @@ func (q *Deque[T]) Set(i int, item T) {
 // only added. Only when items are removed is the queue subject to getting
 // resized smaller.
 func (q *Deque[T]) Clear() {
-	var zero T
-	modBits := len(q.buf) - 1
-	h := q.head
-	for i := 0; i < q.Len(); i++ {
-		q.buf[(h+i)&modBits] = zero
+	head, tail := q.head, q.tail
+
+	if head == tail {
+		// either zero or full, depending on count
+		head = 0
+		tail = q.count
+	} else if head > tail {
+		// non-contiguous buffer, clearing the tail
+		clear(q.buf[:tail])
+		// and setting up to clear the head
+		tail = len(q.buf)
 	}
+	clear(q.buf[head:tail])
 	q.head = 0
 	q.tail = 0
 	q.count = 0

--- a/deque.go
+++ b/deque.go
@@ -166,22 +166,20 @@ func (q *Deque[T]) Set(i int, item T) {
 // only added. Only when items are removed is the queue subject to getting
 // resized smaller.
 func (q *Deque[T]) Clear() {
-	head, tail := q.head, q.tail
-
-	if head == tail {
-		// either zero or full, depending on count
-		head = 0
-		tail = q.count
-	} else if head > tail {
-		// non-contiguous buffer, clearing the tail
-		clear(q.buf[:tail])
-		// and setting up to clear the head
-		tail = len(q.buf)
+	if q.Len() == 0 {
+		return
 	}
-	clear(q.buf[head:tail])
+	head, tail := q.head, q.tail
+	q.count = 0
 	q.head = 0
 	q.tail = 0
-	q.count = 0
+
+	if head >= tail {
+		// [DEF....ABC]
+		clear(q.buf[head:])
+		head = 0
+	}
+	clear(q.buf[head:tail])
 }
 
 // Grow grows deque's capacity, if necessary, to guarantee space for another n

--- a/deque_test.go
+++ b/deque_test.go
@@ -2,6 +2,7 @@ package deque
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"unicode"
 )
@@ -920,5 +921,31 @@ func BenchmarkYoyoFixed(b *testing.B) {
 		for j := 0; j < 65536; j++ {
 			q.PopFront()
 		}
+	}
+}
+
+func BenchmarkClearContiguous(b *testing.B) {
+	var src Deque[int]
+	for i := range 1<<15 + 1<<14 {
+		src.PushBack(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := src
+		q.buf = slices.Clone(q.buf)
+		q.Clear()
+	}
+}
+
+func BenchmarkClearSplit(b *testing.B) {
+	var src Deque[int]
+	for i := range 1<<15 + 1<<14 {
+		src.PushFront(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := src
+		q.buf = slices.Clone(q.buf)
+		q.Clear()
 	}
 }


### PR DESCRIPTION
Using built-in `clear()` to zero-out contiguous array slices instead of zeroing elements one by one

```
name               old time/op    new time/op    delta
ClearContiguous-4     294µs ± 9%     237µs ±36%  -19.23%  (p=0.001 n=13+15)
ClearSplit-4          321µs ±11%     248µs ± 8%  -22.60%  (p=0.000 n=14+13)

name               old alloc/op   new alloc/op   delta
ClearContiguous-4     524kB ± 0%     524kB ± 0%   -0.00%  (p=0.000 n=11+12)
ClearSplit-4          524kB ± 0%     524kB ± 0%   -0.00%  (p=0.000 n=12+15)

name               old allocs/op  new allocs/op  delta
ClearContiguous-4      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
ClearSplit-4           1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```