### PR TITLE
fix panic after IterPopX leaves buffer exactly full

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -660,6 +660,6 @@ func (q *Deque[T]) resize(newSize int) {
 	}
 
 	q.head = 0
-	q.tail = q.count
+	q.tail = q.count & (newSize - 1) // bitwise modulus, in case buffer is exactly full
 	q.buf = newBuf
 }

--- a/deque_test.go
+++ b/deque_test.go
@@ -1303,6 +1303,34 @@ func TestCopyInSlicePanic(t *testing.T) {
 	q.PushBack(17)
 }
 
+func TestShrinkToFitPanic(t *testing.T) {
+	var q Deque[int]
+	for range 33 {
+		q.PushBack(0)
+	}
+	i := 0
+	for range q.IterPopFront() {
+		i++
+		if i == 17 {
+			break
+		}
+	}
+	q.PopFront()
+	q.PushBack(0)
+}
+
+func TestPopFrontPanic(t *testing.T) {
+	var q Deque[int]
+	for range 33 {
+		q.PushBack(0)
+	}
+	for i := 0; i < 17; i++ {
+		q.PopFront()
+	}
+	q.PopFront()
+	q.PushBack(0)
+}
+
 func assertPanics(t *testing.T, name string, f func()) {
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
The internal shrinkToFit function was not wrapping the tail index if the buffer was exactly full.

Closes #48